### PR TITLE
Fixes and new functionality in DateConverter

### DIFF
--- a/TypeScript.Common.Tests/Unit tests/Scripts/affecto/DateConverterTests.ts
+++ b/TypeScript.Common.Tests/Unit tests/Scripts/affecto/DateConverterTests.ts
@@ -105,9 +105,9 @@ describe("Date conversion", () =>
             expect(Affecto.DateConverter.toFinnishDate(null)).toBeNull();
         });
 
-        it("Empty date string is empty date", () =>
+        it("Empty date string is null date", () =>
         {
-            expect(Affecto.DateConverter.toFinnishDate("")).toBe("");
+            expect(Affecto.DateConverter.toFinnishDate("")).toBeNull();
         });
 
         it("Date and time are converted to date", () =>
@@ -122,7 +122,7 @@ describe("Date conversion", () =>
 
         it("Date object is converted to date", () =>
         {
-            expect(Affecto.DateConverter.toFinnishDate(new Date(2014, 11, 17))).toBe("17.12.2014");
+            expect(Affecto.DateConverter.toFinnishDate(new Date(Date.UTC(2014, 11, 17)))).toBe("17.12.2014");
         });
 
         it("Unconvertable date is null date", () =>
@@ -135,9 +135,9 @@ describe("Date conversion", () =>
             expect(Affecto.DateConverter.toFinnishDateTime(null)).toBeNull();
         });
 
-        it("Empty date string is empty date time", () =>
+        it("Empty date string is null date time", () =>
         {
-            expect(Affecto.DateConverter.toFinnishDateTime("")).toBe("");
+            expect(Affecto.DateConverter.toFinnishDateTime("")).toBeNull();
         });
 
         it("Date and time are converted to date time", () =>
@@ -160,22 +160,27 @@ describe("Date conversion", () =>
             expect(Affecto.DateConverter.toFinnishDateTime(new Date(Date.UTC(2014, 11, 17, 3, 10, 9)))).toBe("17.12.2014 03:10:09");
         });
 
+        it("Date object before midnight in UTC time zone is converted to date time with UTC time zone", () =>
+        {
+            expect(Affecto.DateConverter.toFinnishDateTime(new Date(Date.UTC(2014, 11, 17, 23, 10, 9)))).toBe("17.12.2014 23:10:09");
+        });
+
         it("Unconvertable date is null date time", () =>
         {
             expect(Affecto.DateConverter.toFinnishDateTime("no date")).toBeNull();
         });
     });
 
-    describe("to ISO8601 format string", () =>
+    describe("to ISO8601 format date string", () =>
     {
         it("Null date string is null date", () =>
         {
             expect(Affecto.DateConverter.toISO8601Date(null)).toBeNull();
         });
 
-        it("Empty date string is empty date", () =>
+        it("Empty date string is null date", () =>
         {
-            expect(Affecto.DateConverter.toISO8601Date("")).toBe("");
+            expect(Affecto.DateConverter.toISO8601Date("")).toBeNull();
         });
 
         it("Date and time are converted to date", () =>
@@ -185,17 +190,85 @@ describe("Date conversion", () =>
 
         it("Date alone is converted to date", () =>
         {
-            expect(Affecto.DateConverter.toISO8601Date("2014-02-07")).toBe("2014-2-7");
+            expect(Affecto.DateConverter.toISO8601Date("2014-12-27")).toBe("2014-12-27");
+        });
+
+        it("Date alone is converted to date with leading zeros", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601Date("2014-02-07")).toBe("2014-02-07");
         });
 
         it("Date object is converted to date", () =>
         {
-            expect(Affecto.DateConverter.toISO8601Date(new Date(2014, 11, 17))).toBe("2014-12-17");
+            expect(Affecto.DateConverter.toISO8601Date(new Date(Date.UTC(2014, 11, 17)))).toBe("2014-12-17");
+        });
+
+        it("Date object is converted to date with leading zeros", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601Date(new Date(Date.UTC(2014, 2, 9)))).toBe("2014-03-09");
+        });
+
+        it("Date object with time before midnight is converted to date", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601Date(new Date(Date.UTC(2014, 11, 17, 23, 31, 1)))).toBe("2014-12-17");
+        });
+
+        it("Date object with time after midnight is converted to date", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601Date(new Date(Date.UTC(2014, 11, 17, 0, 31, 1)))).toBe("2014-12-17");
         });
 
         it("Unconvertable date is null date", () =>
         {
             expect(Affecto.DateConverter.toISO8601Date("no date")).toBeNull();
+        });
+    });
+
+    describe("to ISO8601 format date and time string", () =>
+    {
+        it("Null date string is null date", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601DateTime(null)).toBeNull();
+        });
+
+        it("Empty date string is null date", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601DateTime("")).toBeNull();
+        });
+
+        it("Date and time are converted to date and time", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601DateTime("2014-12-17T11:33:36.753Z")).toBe("2014-12-17T11:33:36");
+        });
+
+        it("Date alone is converted to date and time", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601DateTime("2014-12-27")).toBe("2014-12-27T00:00:00");
+        });
+
+        it("Date alone is converted to date and time with leading zeros", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601DateTime("2014-02-07")).toBe("2014-02-07T00:00:00");
+        });
+
+        it("Date object is converted to date and time", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601DateTime(new Date(Date.UTC(2014, 11, 17, 0, 0, 0)))).toBe("2014-12-17T00:00:00");
+        });
+
+        it("Date object is converted to date and time with leading zeros", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601DateTime(new Date(Date.UTC(2014, 2, 9, 0, 0, 0)))).toBe("2014-03-09T00:00:00");
+        });
+
+        it("Date object with time is converted to date and time", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601DateTime(new Date(Date.UTC(2014, 11, 17, 22, 13, 1)))).toBe("2014-12-17T22:13:01");
+        });
+
+        it("Unconvertable date is null date", () =>
+        {
+            expect(Affecto.DateConverter.toISO8601DateTime("no date")).toBeNull();
         });
     });
 });

--- a/TypeScript.Common.Tests/Unit tests/Scripts/affecto/DateConverterTests.ts
+++ b/TypeScript.Common.Tests/Unit tests/Scripts/affecto/DateConverterTests.ts
@@ -122,7 +122,7 @@ describe("Date conversion", () =>
 
         it("Date object is converted to date", () =>
         {
-            expect(Affecto.DateConverter.toFinnishDate(new Date(Date.UTC(2014, 11, 17)))).toBe("17.12.2014");
+            expect(Affecto.DateConverter.toFinnishDate(new Date(2014, 11, 17))).toBe("17.12.2014");
         });
 
         it("Unconvertable date is null date", () =>
@@ -155,14 +155,14 @@ describe("Date conversion", () =>
             expect(Affecto.DateConverter.toFinnishDateTime("2014-02-07")).toBe("7.2.2014 00:00:00");
         });
 
-        it("Date object in UTC time zone is converted to date time with UTC time zone", () =>
+        it("Date object is converted to date time", () =>
         {
-            expect(Affecto.DateConverter.toFinnishDateTime(new Date(Date.UTC(2014, 11, 17, 3, 10, 9)))).toBe("17.12.2014 03:10:09");
+            expect(Affecto.DateConverter.toFinnishDateTime(new Date(2014, 11, 17, 3, 10, 9))).toBe("17.12.2014 03:10:09");
         });
 
-        it("Date object before midnight in UTC time zone is converted to date time with UTC time zone", () =>
+        it("Date object before midnight is converted to date time", () =>
         {
-            expect(Affecto.DateConverter.toFinnishDateTime(new Date(Date.UTC(2014, 11, 17, 23, 10, 9)))).toBe("17.12.2014 23:10:09");
+            expect(Affecto.DateConverter.toFinnishDateTime(new Date(2014, 11, 17, 23, 10, 9))).toBe("17.12.2014 23:10:09");
         });
 
         it("Unconvertable date is null date time", () =>
@@ -200,22 +200,22 @@ describe("Date conversion", () =>
 
         it("Date object is converted to date", () =>
         {
-            expect(Affecto.DateConverter.toISO8601Date(new Date(Date.UTC(2014, 11, 17)))).toBe("2014-12-17");
+            expect(Affecto.DateConverter.toISO8601Date(new Date(2014, 11, 17))).toBe("2014-12-17");
         });
 
         it("Date object is converted to date with leading zeros", () =>
         {
-            expect(Affecto.DateConverter.toISO8601Date(new Date(Date.UTC(2014, 2, 9)))).toBe("2014-03-09");
+            expect(Affecto.DateConverter.toISO8601Date(new Date(2014, 2, 9))).toBe("2014-03-09");
         });
 
         it("Date object with time before midnight is converted to date", () =>
         {
-            expect(Affecto.DateConverter.toISO8601Date(new Date(Date.UTC(2014, 11, 17, 23, 31, 1)))).toBe("2014-12-17");
+            expect(Affecto.DateConverter.toISO8601Date(new Date(2014, 11, 17, 23, 31, 1))).toBe("2014-12-17");
         });
 
         it("Date object with time after midnight is converted to date", () =>
         {
-            expect(Affecto.DateConverter.toISO8601Date(new Date(Date.UTC(2014, 11, 17, 0, 31, 1)))).toBe("2014-12-17");
+            expect(Affecto.DateConverter.toISO8601Date(new Date(2014, 11, 17, 0, 31, 1))).toBe("2014-12-17");
         });
 
         it("Unconvertable date is null date", () =>
@@ -253,17 +253,17 @@ describe("Date conversion", () =>
 
         it("Date object is converted to date and time", () =>
         {
-            expect(Affecto.DateConverter.toISO8601DateTime(new Date(Date.UTC(2014, 11, 17, 0, 0, 0)))).toBe("2014-12-17T00:00:00");
+            expect(Affecto.DateConverter.toISO8601DateTime(new Date(2014, 11, 17, 0, 0, 0))).toBe("2014-12-17T00:00:00");
         });
 
         it("Date object is converted to date and time with leading zeros", () =>
         {
-            expect(Affecto.DateConverter.toISO8601DateTime(new Date(Date.UTC(2014, 2, 9, 0, 0, 0)))).toBe("2014-03-09T00:00:00");
+            expect(Affecto.DateConverter.toISO8601DateTime(new Date(2014, 2, 9, 0, 0, 0))).toBe("2014-03-09T00:00:00");
         });
 
         it("Date object with time is converted to date and time", () =>
         {
-            expect(Affecto.DateConverter.toISO8601DateTime(new Date(Date.UTC(2014, 11, 17, 22, 13, 1)))).toBe("2014-12-17T22:13:01");
+            expect(Affecto.DateConverter.toISO8601DateTime(new Date(2014, 11, 17, 22, 13, 1))).toBe("2014-12-17T22:13:01");
         });
 
         it("Unconvertable date is null date", () =>

--- a/TypeScript.Common/Properties/AssemblyInfo.cs
+++ b/TypeScript.Common/Properties/AssemblyInfo.cs
@@ -8,4 +8,4 @@
 [assembly: AssemblyFileVersion("2.0.0.0")]
 
 // This version is used by NuGet:
-[assembly: AssemblyInformationalVersion("2.0.0-prerelease01")]
+[assembly: AssemblyInformationalVersion("2.0.0-prerelease02")]

--- a/TypeScript.Common/Properties/AssemblyInfo.cs
+++ b/TypeScript.Common/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@
 [assembly: AssemblyDescription("TypeScript toolkit including for example comparers, validators and converters.")]
 [assembly: AssemblyCompany("Affecto")]
 
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
 
 // This version is used by NuGet:
-[assembly: AssemblyInformationalVersion("1.5.0")]
+[assembly: AssemblyInformationalVersion("2.0.0-prerelease01")]

--- a/TypeScript.Common/Properties/AssemblyInfo.cs
+++ b/TypeScript.Common/Properties/AssemblyInfo.cs
@@ -8,4 +8,4 @@
 [assembly: AssemblyFileVersion("2.0.0.0")]
 
 // This version is used by NuGet:
-[assembly: AssemblyInformationalVersion("2.0.0")]
+[assembly: AssemblyInformationalVersion("2.0.0-prerelease03")]

--- a/TypeScript.Common/Properties/AssemblyInfo.cs
+++ b/TypeScript.Common/Properties/AssemblyInfo.cs
@@ -8,4 +8,4 @@
 [assembly: AssemblyFileVersion("2.0.0.0")]
 
 // This version is used by NuGet:
-[assembly: AssemblyInformationalVersion("2.0.0-prerelease02")]
+[assembly: AssemblyInformationalVersion("2.0.0")]

--- a/TypeScript.Common/Properties/AssemblyInfo.cs
+++ b/TypeScript.Common/Properties/AssemblyInfo.cs
@@ -8,4 +8,4 @@
 [assembly: AssemblyFileVersion("2.0.0.0")]
 
 // This version is used by NuGet:
-[assembly: AssemblyInformationalVersion("2.0.0-prerelease03")]
+[assembly: AssemblyInformationalVersion("2.0.0")]

--- a/TypeScript.Common/Scripts/affecto/DateConverter.ts
+++ b/TypeScript.Common/Scripts/affecto/DateConverter.ts
@@ -48,8 +48,10 @@ module Affecto
             }
         }
 
-        // Returns string in format yyyy-MM-dd
-        public static toISO8601Date(date: any): string
+        /**
+         * Returns string in format yyyy-MM-dd (for example 2016-06-10)
+         */
+        public static toISO8601Date(date: Date | string): string
         {
             return this.doConversion(date, (dateObject: Date) =>
             {
@@ -57,7 +59,18 @@ module Affecto
             });
         }
 
-        public static toFinnishDate(date: any): string
+        /**
+         * Returns string in format yyyy-MM-ddThh:mm:ss without timezone (for example 2016-06-10T06:40:37)
+         */
+        public static toISO8601DateTime(date: Date | string): string
+        {
+            return this.doConversion(date, (dateObject: Date) =>
+            {
+                return this.getISO8601DateTime(dateObject);
+            });
+        }
+
+        public static toFinnishDate(date: Date | string): string
         {
             return this.doConversion(date, (dateObject: Date) =>
             {
@@ -65,7 +78,7 @@ module Affecto
             });
         }
 
-        public static toFinnishDateTime(dateTime: any): string
+        public static toFinnishDateTime(dateTime: Date | string): string
         {
             return this.doConversion(dateTime, (dateObject: Date) =>
             {
@@ -73,38 +86,58 @@ module Affecto
             });
         }
 
-        private static doConversion(input: string, conversionFunction: Function): string
+        private static doConversion(input: any, conversionFunction: (date: Date) => string): string
         {
-            if (input != null && input !== "")
+            if (input == null || input === "")
             {
-                var dateObject: any = new Date(input);
-                if (!isNaN(dateObject.getDate()))
-                {
-                    return conversionFunction(dateObject);
-                }
                 return null;
             }
-            return input;
+
+            var date: Date;
+            if (input instanceof Date)
+            {
+                date = new Date(input.toISOString());
+            }
+            else if (typeof input === "string")
+            {
+                date = new Date(input as string);
+            }
+            else
+            {
+                return null;
+            }
+
+            if (!isNaN(date.getDate()))
+            {
+                return conversionFunction(date);
+            }
+
+            return null;
         }
 
         private static getISO8601Date(date: Date): string
         {
-            return date.getFullYear() + '-' + this.getMonth(date) + '-' + date.getDate();
+            return date.getUTCFullYear() + "-" + this.leftPadWithZero(this.getMonth(date)) + "-" + this.leftPadWithZero(date.getUTCDate());
+        }
+
+        private static getISO8601DateTime(date: Date): string
+        {
+            return this.getISO8601Date(date) + "T" + this.getTime(date);
         }
 
         private static getFinnishDate(date: Date): string
         {
-            return date.getDate() + "." + this.getMonth(date) + "." + date.getFullYear();
+            return date.getUTCDate() + "." + this.getMonth(date) + "." + date.getUTCFullYear();
         }
 
         private static getMonth(date: Date): number
         {
-            return date.getMonth() + 1;
+            return date.getUTCMonth() + 1;
         }
 
         private static getTime(date: Date): string
         {
-            return this.leftPadWithZero(date.getUTCHours()) + ":" + this.leftPadWithZero(date.getMinutes()) + ":" + this.leftPadWithZero(date.getSeconds());
+            return this.leftPadWithZero(date.getUTCHours()) + ":" + this.leftPadWithZero(date.getUTCMinutes()) + ":" + this.leftPadWithZero(date.getUTCSeconds());
         }
 
         private static leftPadWithZero(value: number): string

--- a/TypeScript.Common/Scripts/affecto/DateConverter.ts
+++ b/TypeScript.Common/Scripts/affecto/DateConverter.ts
@@ -96,7 +96,8 @@ module Affecto
             var date: Date;
             if (input instanceof Date)
             {
-                date = input;
+                date = new Date(Date.UTC(input.getFullYear(), input.getMonth(), input.getDate(),
+                    input.getHours(), input.getMinutes(), input.getSeconds(), input.getMilliseconds()));
             }
             else if (typeof input === "string")
             {

--- a/TypeScript.Common/Scripts/affecto/DateConverter.ts
+++ b/TypeScript.Common/Scripts/affecto/DateConverter.ts
@@ -96,7 +96,7 @@ module Affecto
             var date: Date;
             if (input instanceof Date)
             {
-                date = new Date(input.toISOString());
+                date = input;
             }
             else if (typeof input === "string")
             {

--- a/TypeScript.Common/TypeScript.Common.nuspec
+++ b/TypeScript.Common/TypeScript.Common.nuspec
@@ -7,7 +7,8 @@
     <description>$description$</description>
     <projectUrl>https://github.com/affecto/dotnet-TypeScript.Common</projectUrl>
     <tags>affecto typescript common compare convert converter validate validator date datetime number html escape unescape decode encode</tags>
-    <releaseNotes>Added DateConverter method toISO8601Date.</releaseNotes>
+    <releaseNotes>Refactored DateConverter to handle UTC dates by default. Added a method for converting date to ISO string without timezone.
+    </releaseNotes>
   </metadata>
   <files>
     <file src="Scripts\affecto\**\*.ts" target="content\Scripts\affecto"/>


### PR DESCRIPTION
Fixed and refactored DateConverter to handle UTC dates by default. Added a method for converting a date to ISO string without timezone.
